### PR TITLE
Added extern for GCC

### DIFF
--- a/src_base/xeve_tq.h
+++ b/src_base/xeve_tq.h
@@ -43,7 +43,7 @@ int xeve_rdoq_set_ctx_cc(XEVE_CORE * core, int ch_type, int prev_level);
 int xeve_sub_block_tq(XEVE_CTX * ctx, XEVE_CORE * core, s16 coef[N_C][MAX_CU_DIM], int log2_cuw, int log2_cuh, int slice_type, int nnz[N_C], int is_intra, int run_stats);
 int xeve_rdoq_run_length_cc(u8 qp, double d_lambda, u8 is_intra, s16 *src_coef, s16 *dst_tmp, int log2_cuw, int log2_cuh, int ch_type, XEVE_CORE * core, int bit_depth);
 void xeve_init_err_scale(XEVE_CTX * ctx);
-const XEVE_TXB(*xeve_func_txb)[MAX_TR_LOG2];
+extern const XEVE_TXB(*xeve_func_txb)[MAX_TR_LOG2];
 void tx_pb2b(void* src, void* dst, int shift, int line, int step);
 void tx_pb4b(void* src, void* dst, int shift, int line, int step);
 void tx_pb8b(void* src, void* dst, int shift, int line, int step);

--- a/src_main/xevem_itdq.h
+++ b/src_main/xevem_itdq.h
@@ -52,6 +52,6 @@ void xeve_itrans_ats_intra_DCT8_B4(s16 *coeff, s16 *block, int shift, int line, 
 void xeve_itrans_ats_intra_DCT8_B8(s16 *coeff, s16 *block, int shift, int line, int skip_line, int skip_line_2);
 void xeve_itrans_ats_intra_DCT8_B16(s16 *coeff, s16 *block, int shift, int line, int skip_line, int skip_line_2);
 void xeve_itrans_ats_intra_DCT8_B32(s16 *coeff, s16 *block, int shift, int line, int skip_line, int skip_line_2);
-const XEVE_ITX(*xeve_func_itx)[MAX_TR_LOG2];
-const XEVE_ITX xeve_tbl_itx[MAX_TR_LOG2];
+extern const XEVE_ITX(*xeve_func_itx)[MAX_TR_LOG2];
+extern const XEVE_ITX xeve_tbl_itx[MAX_TR_LOG2];
 #endif /* _XEVEM_ITDQ_H_ */

--- a/src_main/xevem_tq.h
+++ b/src_main/xevem_tq.h
@@ -40,8 +40,8 @@
 
 int xevem_rdoq_set_ctx_cc(XEVE_CORE * core, int ch_type, int prev_level);
 int xevem_sub_block_tq(XEVE_CTX * ctx, XEVE_CORE * core, s16 coef[N_C][MAX_CU_DIM], int log2_cuw, int log2_cuh, int slice_type, int nnz[N_C], int is_intra, int run_stats);
-const XEVE_TX(*xeve_func_tx)[MAX_TR_LOG2];
-const XEVE_TX xeve_tbl_tx[MAX_TR_LOG2];
+extern const XEVE_TX(*xeve_func_tx)[MAX_TR_LOG2];
+extern const XEVE_TX xeve_tbl_tx[MAX_TR_LOG2];
 void tx_pb2(s16* src, s16* dst, int shift, int line);
 void tx_pb4(s16* src, s16* dst, int shift, int line);
 void tx_pb8(s16* src, s16* dst, int shift, int line);


### PR DESCRIPTION
Codec doesn't want defined reference:
```
c:/msys1200/bin/../lib/gcc/x86_64-w64-mingw32/12.0.0/../../../../x86_64-w64-mingw32/bin/ld.exe: xevem_util.o:xevem_util.c:(.rdata$.refptr.xeve_tbl_itx[.refptr.xeve_tbl_itx]+0x0): undefined reference to `xeve_tbl_itx'
```