### PR TITLE
Reordered the bytes of a 32-bit NAL unit prefixes storing NAL unit si…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,15 @@ project (XEVE VERSION 1.0.0)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Set compiler flags and options. 
+
+message("Processor byte order: ${CMAKE_C_BYTE_ORDER}")
+
+if( ${CMAKE_C_BYTE_ORDER} STREQUAL "LITTLE_ENDIAN")
+  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -DLITTLE_ENDIAN_BYTE_ORDER)
+else()
+  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -DBIG_ENDIAN_BYTE_ORDER)
+endif()
+
 if( MSVC )
 elseif( UNIX OR MINGW )
     if(NOT CMAKE_BUILD_TYPE)
@@ -46,8 +55,8 @@ elseif( UNIX OR MINGW )
 endif()
 
 # Command to output information to the console
-message ("c Flags: " ${CMAKE_C_FLAGS})
-message ("linker Flags: " ${CMAKE_EXE_LINKER_FLAGS})
+message ("C Flags: " ${CMAKE_C_FLAGS})
+message ("Linker Flags: " ${CMAKE_EXE_LINKER_FLAGS})
 
 # Sub-directories where more CMakeLists.txt exist
 if(("${SET_PROF}" STREQUAL "BASE"))

--- a/inc/xeve.h
+++ b/inc/xeve.h
@@ -39,6 +39,39 @@ extern "C"
 
 #include <xeve_exports.h>
 
+
+#define is_bigendian() (!*(unsigned char *)&(uint16_t){1})
+
+#define XEVE_REVERSE_BYTE_ORDER_SHORT(data) ((unsigned short) \
+( (((data) >> 8) & 0x00FF) | (((data) << 8) & 0xFF00) )  )
+
+#define XEVE_REVERSE_BYTE_ORDER_LONG(data) ((unsigned long)  \
+( (((data) >> 24) & 0x000000FF) | (((data) >>  8) & 0x0000FF00) | \
+  (((data) <<  8) & 0x00FF0000) | (((data) << 24) & 0xFF000000) ) )
+
+#define XEVE_REVERSE_BYTE_ORDER_LONG_LONG(data) ((unsigned long long)  \
+( (((data) >> 56) & 0x00000000000000FF) | (((data) >> 40) & 0x000000000000FF00) | \
+  (((data) >> 24) & 0x0000000000FF0000) | (((data) >>  8) & 0x00000000FF000000) | \
+  (((data) <<  8) & 0x000000FF00000000) | (((data) << 24) & 0x0000FF0000000000) | \
+  (((data) << 40) & 0x00FF000000000000) | (((data) << 56) & 0xFF00000000000000) ) )
+
+
+#ifdef LITTLE_ENDIAN_BYTE_ORDER
+#    define XEVE_LITTLE_ENDIAN_SHORT(n) (n)
+#    define XEVE_LITTLE_ENDIAN_LONG(n) (n)
+#    define XEVE_LITTLE_ENDIAN_LONG_LONG(n) (n)
+#    define XEVE_BIG_ENDIAN_SHORT(n) XEVE_REVERSE_BYTE_ORDER_SHORT(n)
+#    define XEVE_BIG_ENDIAN_LONG(n) XEVE_REVERSE_BYTE_ORDER_LONG(n)
+#    define XEVE_BIG_ENDIAN_LONG_LONG(n) XEVE_REVERSE_BYTE_ORDER_LONG_LONG(n)
+#else
+#    define XEVE_LITTLE_ENDIAN_SHORT(n) XEVE_REVERSE_BYTE_ORDER_SHORT(n)
+#    define XEVE_LITTLE_ENDIAN_LONG(n) XEVE_REVERSE_BYTE_ORDER_LONG(n)
+#    define XEVE_LITTLE_ENDIAN_LONG_LONG(n) XEVE_REVERSE_BYTE_ORDER_LONG(n)
+#    define XEVE_BIG_ENDIAN_SHORT(n) (n)
+#    define XEVE_BIG_ENDIAN_LONG(n) (n)
+#    define XEVE_BIG_ENDIAN_LONG_LONG(n) (n)
+#endif
+
 #define XEVE_MAX_THREADS                 (8)
 #define XEVE_MAX_NUM_TILES_ROW           (22)
 #define XEVE_MAX_NUM_TILES_COL           (20)

--- a/src_base/xeve.c
+++ b/src_base/xeve.c
@@ -31,6 +31,12 @@
 #include <math.h>
 #include "xeve_type.h"
 
+#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
+#include <winsock.h>
+#else
+#include <arpa/inet.h>
+#endif
+
 static int xeve_eco_tree(XEVE_CTX * ctx, XEVE_CORE * core, int x0, int y0, int cup, int cuw, int cuh, int cud
                        , int cu_qp_delta_code, TREE_CONS tree_cons, XEVE_BSW * bs)
 {
@@ -507,7 +513,11 @@ int xeve_pic(XEVE_CTX * ctx, XEVE_BITB * bitb, XEVE_STAT * stat)
         }
 
         xeve_bsw_deinit(bs);
-        *size_field = (int)(bs->cur - cur_tmp) - 4;
+
+        /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
+        /* write the bitstream size */
+        *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+        
         curr_temp = bs->cur;
 
         /* slice header re-writing */

--- a/src_base/xeve.c
+++ b/src_base/xeve.c
@@ -31,12 +31,6 @@
 #include <math.h>
 #include "xeve_type.h"
 
-#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
-#include <winsock.h>
-#else
-#include <arpa/inet.h>
-#endif
-
 static int xeve_eco_tree(XEVE_CTX * ctx, XEVE_CORE * core, int x0, int y0, int cup, int cuw, int cuh, int cud
                        , int cu_qp_delta_code, TREE_CONS tree_cons, XEVE_BSW * bs)
 {
@@ -516,7 +510,7 @@ int xeve_pic(XEVE_CTX * ctx, XEVE_BITB * bitb, XEVE_STAT * stat)
 
         /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
         /* write the bitstream size */
-        *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+        *size_field = XEVE_BIG_ENDIAN_LONG((int)(bs->cur - cur_tmp) - 4);
         
         curr_temp = bs->cur;
 

--- a/src_base/xeve_util.c
+++ b/src_base/xeve_util.c
@@ -31,6 +31,12 @@
 #include "xeve_type.h"
 #include <math.h>
 
+#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
+#include <winsock.h>
+#else
+#include <arpa/inet.h>
+#endif
+
 #define TX_SHIFT1(log2_size, bd)   ((log2_size) - 1 + bd - 8)
 #define TX_SHIFT2(log2_size)   ((log2_size) + 6)
 
@@ -2657,7 +2663,7 @@ int xeve_pic_finish(XEVE_CTX *ctx, XEVE_BITB *bitb, XEVE_STAT *stat)
 
         xeve_bsw_deinit(bs);
         stat->sei_size = (int)(bs->cur - cur_tmp);
-        *size_field = stat->sei_size - 4;
+        *size_field = htonl(stat->sei_size - 4);
     }
 
     /* expand current encoding picture, if needs */
@@ -3824,7 +3830,7 @@ int xeve_encode_sps(XEVE_CTX * ctx)
     xeve_bsw_deinit(bs);
 
     /* write the bitstream size */
-    *size_field = (int)(bs->cur - cur_tmp) - 4;
+    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }
@@ -3850,7 +3856,7 @@ int xeve_encode_pps(XEVE_CTX * ctx)
     xeve_bsw_deinit(bs);
 
     /* write the bitstream size */
-    *size_field = (int)(bs->cur - cur_tmp) - 4;
+    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }

--- a/src_base/xeve_util.c
+++ b/src_base/xeve_util.c
@@ -31,12 +31,6 @@
 #include "xeve_type.h"
 #include <math.h>
 
-#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
-#include <winsock.h>
-#else
-#include <arpa/inet.h>
-#endif
-
 #define TX_SHIFT1(log2_size, bd)   ((log2_size) - 1 + bd - 8)
 #define TX_SHIFT2(log2_size)   ((log2_size) + 6)
 
@@ -2665,7 +2659,7 @@ int xeve_pic_finish(XEVE_CTX *ctx, XEVE_BITB *bitb, XEVE_STAT *stat)
 
         /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
         /* write the bitstream size */
-        *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+        *size_field = XEVE_BIG_ENDIAN_LONG((int)(bs->cur - cur_tmp) - 4);
     }
 
     /* expand current encoding picture, if needs */
@@ -3833,7 +3827,7 @@ int xeve_encode_sps(XEVE_CTX * ctx)
 
     /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
-    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+    *size_field = XEVE_BIG_ENDIAN_LONG((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }
@@ -3860,7 +3854,7 @@ int xeve_encode_pps(XEVE_CTX * ctx)
 
     /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
-    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+    *size_field = XEVE_BIG_ENDIAN_LONG((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }

--- a/src_base/xeve_util.c
+++ b/src_base/xeve_util.c
@@ -2662,8 +2662,10 @@ int xeve_pic_finish(XEVE_CTX *ctx, XEVE_BITB *bitb, XEVE_STAT *stat)
         xeve_assert_rv(ret == XEVE_OK, ret);
 
         xeve_bsw_deinit(bs);
-        stat->sei_size = (int)(bs->cur - cur_tmp);
-        *size_field = htonl(stat->sei_size - 4);
+
+        /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
+        /* write the bitstream size */
+        *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
     }
 
     /* expand current encoding picture, if needs */
@@ -3829,6 +3831,7 @@ int xeve_encode_sps(XEVE_CTX * ctx)
     /* de-init BSW */
     xeve_bsw_deinit(bs);
 
+    /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
     *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 
@@ -3855,6 +3858,7 @@ int xeve_encode_pps(XEVE_CTX * ctx)
     /* de-init BSW */
     xeve_bsw_deinit(bs);
 
+    /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
     *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 

--- a/src_main/xevem.c
+++ b/src_main/xevem.c
@@ -36,6 +36,12 @@
 #include <math.h>
 #include "xevem_type.h"
 
+#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
+#include <winsock.h>
+#else
+#include <arpa/inet.h>
+#endif
+
 static int xeve_eco_tree(XEVE_CTX * ctx, XEVE_CORE * core, int x0, int y0, int cup, int cuw, int cuh, int cud
                        , int next_split, const int parent_split, int* same_layer_split, const int node_idx, const int* parent_split_allow
                        , int qt_depth, int btt_depth, int cu_qp_delta_code, TREE_CONS tree_cons, XEVE_BSW * bs)
@@ -708,7 +714,11 @@ int xeve_pic(XEVE_CTX * ctx, XEVE_BITB * bitb, XEVE_STAT * stat)
         }
 
         xeve_bsw_deinit(bs);
-        *size_field = (int)(bs->cur - cur_tmp) - 4;
+        
+        /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
+        /* write the bitstream size */
+        *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+
         curr_temp = bs->cur;
 
         /* slice header re-writing */

--- a/src_main/xevem.c
+++ b/src_main/xevem.c
@@ -36,12 +36,6 @@
 #include <math.h>
 #include "xevem_type.h"
 
-#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
-#include <winsock.h>
-#else
-#include <arpa/inet.h>
-#endif
-
 static int xeve_eco_tree(XEVE_CTX * ctx, XEVE_CORE * core, int x0, int y0, int cup, int cuw, int cuh, int cud
                        , int next_split, const int parent_split, int* same_layer_split, const int node_idx, const int* parent_split_allow
                        , int qt_depth, int btt_depth, int cu_qp_delta_code, TREE_CONS tree_cons, XEVE_BSW * bs)
@@ -717,7 +711,7 @@ int xeve_pic(XEVE_CTX * ctx, XEVE_BITB * bitb, XEVE_STAT * stat)
         
         /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
         /* write the bitstream size */
-        *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+        *size_field = XEVE_BIG_ENDIAN_LONG((int)(bs->cur - cur_tmp) - 4);
 
         curr_temp = bs->cur;
 

--- a/src_main/xevem_util.c
+++ b/src_main/xevem_util.c
@@ -35,12 +35,6 @@
 
 #include "xevem_util.h"
 
-#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
-#include <winsock.h>
-#else
-#include <arpa/inet.h>
-#endif
-
 #if GRAB_STAT
 #include "xevem_stat.h"
 #endif
@@ -4075,7 +4069,7 @@ int xevem_encode_sps(XEVE_CTX * ctx)
 
     /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
-    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+    *size_field = XEVE_BIG_ENDIAN_LONG((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }
@@ -4098,7 +4092,7 @@ int xevem_encode_aps(XEVE_CTX * ctx, XEVE_APS_GEN * aps)
 
     /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
-    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+    *size_field = XEVE_BIG_ENDIAN_LONG((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }
@@ -4124,7 +4118,7 @@ int xevem_encode_pps(XEVE_CTX * ctx)
 
     /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
-    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
+    *size_field = XEVE_BIG_ENDIAN_LONG((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }

--- a/src_main/xevem_util.c
+++ b/src_main/xevem_util.c
@@ -35,6 +35,12 @@
 
 #include "xevem_util.h"
 
+#if (defined(_WIN64) || defined(_WIN32)) && !defined(__GNUC__)
+#include <winsock.h>
+#else
+#include <arpa/inet.h>
+#endif
+
 #if GRAB_STAT
 #include "xevem_stat.h"
 #endif
@@ -4068,7 +4074,7 @@ int xevem_encode_sps(XEVE_CTX * ctx)
     xeve_bsw_deinit(bs);
 
     /* write the bitstream size */
-    *size_field = (int)(bs->cur - cur_tmp) - 4;
+    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }
@@ -4088,7 +4094,7 @@ int xevem_encode_aps(XEVE_CTX * ctx, XEVE_APS_GEN * aps)
     xeve_assert_rv(xevem_eco_aps_gen(bs, aps, ctx->sps.bit_depth_luma_minus8 + 8) == XEVE_OK, XEVE_ERR_INVALID_ARGUMENT);
 
     xeve_bsw_deinit(bs);
-    *size_field = (int)(bs->cur - cur_tmp) - 4;
+    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }
@@ -4113,7 +4119,7 @@ int xevem_encode_pps(XEVE_CTX * ctx)
     xeve_bsw_deinit(bs);
 
     /* write the bitstream size */
-    *size_field = (int)(bs->cur - cur_tmp) - 4;
+    *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
 }

--- a/src_main/xevem_util.c
+++ b/src_main/xevem_util.c
@@ -4073,6 +4073,7 @@ int xevem_encode_sps(XEVE_CTX * ctx)
     /* de-init BSW */
     xeve_bsw_deinit(bs);
 
+    /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
     *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 
@@ -4094,6 +4095,9 @@ int xevem_encode_aps(XEVE_CTX * ctx, XEVE_APS_GEN * aps)
     xeve_assert_rv(xevem_eco_aps_gen(bs, aps, ctx->sps.bit_depth_luma_minus8 + 8) == XEVE_OK, XEVE_ERR_INVALID_ARGUMENT);
 
     xeve_bsw_deinit(bs);
+
+    /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
+    /* write the bitstream size */
     *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 
     return XEVE_OK;
@@ -4118,6 +4122,7 @@ int xevem_encode_pps(XEVE_CTX * ctx)
     /* de-init BSW */
     xeve_bsw_deinit(bs);
 
+    /* reorder the bytes of a 32-bit bitstream size value from processor order to network order */
     /* write the bitstream size */
     *size_field = htonl((int)(bs->cur - cur_tmp) - 4);
 


### PR DESCRIPTION
…zes value from processor byte order to network byte order

If encoder runs on a little-endian processor, the bytes of NALU size prefix wil be reoredred
If the stack runs on a big-endian processor, there’s nothing will be done