### PR TITLE
Fix cross compilation of Windows on Linux

### DIFF
--- a/src_base/xeve_thread_pool.c
+++ b/src_base/xeve_thread_pool.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include "xeve_thread_pool.h"
 #if defined(WIN32) || defined(WIN64)
-#include <Windows.h>
+#include <windows.h>
 #include <process.h>
 #else
 #include <pthread.h>


### PR DESCRIPTION
This will solve the problem by changing from Windows.h to windows.h for smallcase first letter.