### PR TITLE
Fixed bug causing multiple definition errors.

### DIFF
--- a/src_main/sse/xevem_mc_sse.c
+++ b/src_main/sse/xevem_mc_sse.c
@@ -43,7 +43,7 @@
  ****************************************************************************/
 static const s8 shuffle_2tap[16] = { 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 8, 9 };
 
-void mc_filter_bilin_horz_sse(s16 const *ref,
+static void xeve_mc_filter_bilin_horz_sse(s16 const *ref,
     int src_stride,
     s16 *pred,
     int dst_stride,
@@ -352,7 +352,7 @@ void mc_filter_bilin_horz_sse(s16 const *ref,
     }
 }
 
-void mc_filter_bilin_vert_sse(s16 const *ref,
+static void xeve_mc_filter_bilin_vert_sse(s16 const *ref,
     int src_stride,
     s16 *pred,
     int dst_stride,
@@ -782,7 +782,7 @@ void xeve_bl_mc_l_n0_sse(pel *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, 
     int max = ((1 << bit_depth) - 1);
     int min = 0;
 
-    mc_filter_bilin_horz_sse(ref, s_ref, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dx], w, h, min, max, MAC_ADD_N0, MAC_SFT_N0, 1);
+    xeve_mc_filter_bilin_horz_sse(ref, s_ref, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dx], w, h, min, max, MAC_ADD_N0, MAC_SFT_N0, 1);
 }
 
 void xeve_bl_mc_l_0n_sse(pel *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, pel *pred, int w, int h, int bit_depth)
@@ -793,7 +793,7 @@ void xeve_bl_mc_l_0n_sse(pel *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, 
     int max = ((1 << bit_depth) - 1);
     int min = 0;
 
-    mc_filter_bilin_vert_sse(ref, s_ref, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dy], w, h, min, max, MAC_ADD_0N, MAC_SFT_0N, 1);
+    xeve_mc_filter_bilin_vert_sse(ref, s_ref, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dy], w, h, min, max, MAC_ADD_0N, MAC_SFT_0N, 1);
 }
 
 void xeve_bl_mc_l_nn_sse(s16 *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, s16 *pred, int w, int h, int bit_depth)
@@ -813,8 +813,8 @@ void xeve_bl_mc_l_nn_sse(s16 *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, 
     int max = ((1 << bit_depth) - 1);
     int min = 0;
 
-    mc_filter_bilin_horz_sse(ref, s_ref, buf, w, xeve_tbl_bl_mc_l_coeff[dx], w, (h + 1), min, max, offset1, shift1, 0);
-    mc_filter_bilin_vert_sse(buf, w, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dy], w, h, min, max, offset2, shift2, 1);
+    xeve_mc_filter_bilin_horz_sse(ref, s_ref, buf, w, xeve_tbl_bl_mc_l_coeff[dx], w, (h + 1), min, max, offset1, shift1, 0);
+    xeve_mc_filter_bilin_vert_sse(buf, w, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dy], w, h, min, max, offset2, shift2, 1);
 }
 
 /****************************************************************************

--- a/src_main/sse/xevem_mc_sse.c
+++ b/src_main/sse/xevem_mc_sse.c
@@ -43,7 +43,7 @@
  ****************************************************************************/
 static const s8 shuffle_2tap[16] = { 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 8, 9 };
 
-static void xeve_mc_filter_bilin_horz_sse(s16 const *ref,
+static void mc_filter_bilin_horz_sse(s16 const *ref,
     int src_stride,
     s16 *pred,
     int dst_stride,
@@ -352,7 +352,7 @@ static void xeve_mc_filter_bilin_horz_sse(s16 const *ref,
     }
 }
 
-static void xeve_mc_filter_bilin_vert_sse(s16 const *ref,
+static void mc_filter_bilin_vert_sse(s16 const *ref,
     int src_stride,
     s16 *pred,
     int dst_stride,
@@ -782,7 +782,7 @@ void xeve_bl_mc_l_n0_sse(pel *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, 
     int max = ((1 << bit_depth) - 1);
     int min = 0;
 
-    xeve_mc_filter_bilin_horz_sse(ref, s_ref, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dx], w, h, min, max, MAC_ADD_N0, MAC_SFT_N0, 1);
+    mc_filter_bilin_horz_sse(ref, s_ref, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dx], w, h, min, max, MAC_ADD_N0, MAC_SFT_N0, 1);
 }
 
 void xeve_bl_mc_l_0n_sse(pel *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, pel *pred, int w, int h, int bit_depth)
@@ -793,7 +793,7 @@ void xeve_bl_mc_l_0n_sse(pel *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, 
     int max = ((1 << bit_depth) - 1);
     int min = 0;
 
-    xeve_mc_filter_bilin_vert_sse(ref, s_ref, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dy], w, h, min, max, MAC_ADD_0N, MAC_SFT_0N, 1);
+    mc_filter_bilin_vert_sse(ref, s_ref, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dy], w, h, min, max, MAC_ADD_0N, MAC_SFT_0N, 1);
 }
 
 void xeve_bl_mc_l_nn_sse(s16 *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, s16 *pred, int w, int h, int bit_depth)
@@ -813,8 +813,8 @@ void xeve_bl_mc_l_nn_sse(s16 *ref, int gmv_x, int gmv_y, int s_ref, int s_pred, 
     int max = ((1 << bit_depth) - 1);
     int min = 0;
 
-    xeve_mc_filter_bilin_horz_sse(ref, s_ref, buf, w, xeve_tbl_bl_mc_l_coeff[dx], w, (h + 1), min, max, offset1, shift1, 0);
-    xeve_mc_filter_bilin_vert_sse(buf, w, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dy], w, h, min, max, offset2, shift2, 1);
+    mc_filter_bilin_horz_sse(ref, s_ref, buf, w, xeve_tbl_bl_mc_l_coeff[dx], w, (h + 1), min, max, offset1, shift1, 0);
+    mc_filter_bilin_vert_sse(buf, w, pred, s_pred, xeve_tbl_bl_mc_l_coeff[dy], w, h, min, max, offset2, shift2, 1);
 }
 
 /****************************************************************************


### PR DESCRIPTION
Multiple definitions of `mc_filter_bilin_horz_sse' and `mc_filter_bilin_vert_sse' bugs while linking statically against libxeve and libxevd have been fixed
Added appropriate prefixes to avoid conflicts and declared these functions as static to limit their scope to the file in which they are declared