### PR TITLE
xevem_alf.h: Drop typedef redefinition for C99 compatibility

### DIFF
--- a/src_main/xevem_alf.h
+++ b/src_main/xevem_alf.h
@@ -179,7 +179,7 @@ static const int pattern_to_large_filter7[13] =
   10,11,12,13
 };
 
-typedef struct _ALF_FILTER_SHAPE
+struct _ALF_FILTER_SHAPE
 {
     int filter_type;
     int filterLength;
@@ -190,7 +190,7 @@ typedef struct _ALF_FILTER_SHAPE
     int golombIdx[14];
     int pattern_to_large_filter[13];
 
-} ALF_FILTER_SHAPE;
+};
 
 struct _ALF_SLICE_PARAM
 {


### PR DESCRIPTION
Fixes #124

I opted for dropping the typedef on the struct declaration because the `xeve_type.h` header is included indirectly via `xevem_type.h` and I assume the forward declaration of the typedef is intentional.

(I'm splitting up #122 into self-contained PRs to make reviewing easier.)