### PR TITLE
xevem_util: Avoid skipping cnt_tmp values

### DIFF
--- a/src_main/xevem_util.c
+++ b/src_main/xevem_util.c
@@ -2022,7 +2022,6 @@ void xeve_get_affine_motion_scaling(int poc, int scup, int lidx, s8 cur_refi, in
             mvp[cnt_tmp][1][MV_Y] = 0;
             mvp[cnt_tmp][2][MV_X] = 0;
             mvp[cnt_tmp][2][MV_Y] = 0;
-            cnt_tmp++;
         }
     }
 }


### PR DESCRIPTION
This fixes a potential bug where a loop in `xevem_util.c` is iterating over an array with a step size of 2.

(I'm splitting this out of #122 because it's not really related to Darwin support, just a potential bug I came across in Clang warnings.)