### PR TITLE
pkgconfig: Use CMAKE_INSTALL_FULL_*

### DIFF
--- a/pkgconfig/xeve.pc.in
+++ b/pkgconfig/xeve.pc.in
@@ -1,8 +1,8 @@
 # --- xeve.pc.in file ---
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@LIB_NAME@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@LIB_NAME@
 
 Name: xeve
 Description: eXtra-fast Essential Video Encoder (XEVE) (MAIN profile)

--- a/pkgconfig/xeveb.pc.in
+++ b/pkgconfig/xeveb.pc.in
@@ -1,8 +1,8 @@
 # --- xeveb.pc.in file ---
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/@LIB_NAME_BASE@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@LIB_NAME_BASE@
 
 Name: xeveb
 Description: eXtra-fast Essential Video Encoder (XEVE) (BASE profile)


### PR DESCRIPTION
Rather than manually prefixing CMAKE_INSTALL_PREFIX, use the CMAKE_INSTALL_FULL_* variants. This prevents ending up with a non-existent path when the CMAKE_INSTALL_* paths are already absolute.

(Splitting this out of #122 since it's not strictly speaking about Darwin compatibility, we do need this in Nixpkgs but that's a downstream concern.)