### PR TITLE
Increase input y4m buffer size

### DIFF
--- a/app/xeve_app.c
+++ b/app/xeve_app.c
@@ -485,7 +485,7 @@ int y4m_header_parser(FILE * ip_y4m, Y4M_INFO * y4m)
 {
     const size_t y4mheadersize = 256;
 
-    char buffer[256] = { 0 };
+    char buffer[y4mheadersize];
     int ret;
     int i;
 

--- a/app/xeve_app.c
+++ b/app/xeve_app.c
@@ -486,6 +486,8 @@ int y4m_header_parser(FILE * ip_y4m, Y4M_INFO * y4m)
     const size_t y4mheadersize = 256;
 
     char buffer[y4mheadersize];
+    memset(buffer, 0, y4mheadersize);
+
     int ret;
     int i;
 

--- a/app/xeve_app.c
+++ b/app/xeve_app.c
@@ -483,12 +483,12 @@ static int y4m_parse_tags(Y4M_INFO * y4m, char * tags)
 
 int y4m_header_parser(FILE * ip_y4m, Y4M_INFO * y4m)
 {
-    char buffer[80] = { 0 };
+    char buffer[90] = { 0 };
     int ret;
     int i;
 
-    /*Read until newline, or 80 cols, whichever happens first.*/
-    for (i = 0; i < 79; i++)
+    /*Read until newline, or 90 cols, whichever happens first.*/
+    for (i = 0; i < 89; i++)
     {
 
         if (!fread(buffer + i, 1, 1, ip_y4m)) return -1;
@@ -496,7 +496,7 @@ int y4m_header_parser(FILE * ip_y4m, Y4M_INFO * y4m)
         if (buffer[i] == '\n') break;
     }
     /*We skipped too much header data.*/
-   if (i == 79) {
+   if (i == 89) {
         logerr("Error parsing header; not a YUV2MPEG2 file?\n");
         return -1;
     }

--- a/app/xeve_app.c
+++ b/app/xeve_app.c
@@ -483,12 +483,14 @@ static int y4m_parse_tags(Y4M_INFO * y4m, char * tags)
 
 int y4m_header_parser(FILE * ip_y4m, Y4M_INFO * y4m)
 {
-    char buffer[90] = { 0 };
+    const size_t y4mheadersize = 256;
+
+    char buffer[256] = { 0 };
     int ret;
     int i;
 
-    /*Read until newline, or 90 cols, whichever happens first.*/
-    for (i = 0; i < 89; i++)
+    /*Read until newline, or 256 cols, whichever happens first.*/
+    for (i = 0; i < y4mheadersize-1; i++)
     {
 
         if (!fread(buffer + i, 1, 1, ip_y4m)) return -1;
@@ -496,7 +498,7 @@ int y4m_header_parser(FILE * ip_y4m, Y4M_INFO * y4m)
         if (buffer[i] == '\n') break;
     }
     /*We skipped too much header data.*/
-   if (i == 89) {
+   if (i == y4mheadersize-1) {
         logerr("Error parsing header; not a YUV2MPEG2 file?\n");
         return -1;
     }


### PR DESCRIPTION
Hello / witam :)

When trying to encode input `.y4m` file with `xeve_app` I got the following error
```shell
$ xeve_app -i dnd.y4m -q 30 --keyint 128 --profile main --preset medium --threads 8 -o dnd.xeve-evc_main_medium_g128_q30.evc
XEVE: eXtra-fast Essential Video Encoder
[xeve_app.c:500] Error parsing header; not a YUV2MPEG2 file?
[xeve_app.c:1021] This y4m is not supported (dnd.y4m)
fish: Job 1, '~/Downloads/Sources/xeve_new/bu…' terminated by signal SIGSEGV (Address boundary error)
```

Which was weird since I just created this `.y4m` file with FFmpeg and was sure it's valid.

```shell
$ dd if=dnd.y4m count=96 bs=1 | xxd
00000000: 5955 5634 4d50 4547 3220 5731 3932 3020  YUV4MPEG2 W1920 
00000010: 4831 3038 3020 4632 3430 3030 3a31 3030  H1080 F24000:100
00000020: 3120 4970 2041 313a 3120 4334 3230 6a70  1 Ip A1:1 C420jp
00000030: 6567 2058 5953 4353 533d 3432 304a 5045  eg XYSCSS=420JPE
00000040: 4720 5843 4f4c 4f52 5241 4e47 453d 4c49  G XCOLORRANGE=LI
00000050: 4d49 5445 440a 4652 414d 450a 1010 1010  MITED.FRAME.....
```

Turns out the file has header of length 86 but `xeve_app` only reads first 80 bytes of the it.

[The spec](https://manned.org/yuv4mpeg.5) doesn't tell how long could the header be. The original mjpegtools library [has](https://github.com/keithw/mympeg2enc/blob/f19e65a9e79f0889ae52e69f9c7570f1ea2348a6/yuv4mpeg_intern.h#L31) 256 byte buffer for the header but FFmpeg [reserves just](https://ffmpeg.org/doxygen/trunk/yuv4mpeg_8c.html#5847680524a29288bdb87b64c2e3df86) 80 + 10 headroom bytes for *optional features*.
I think it's safe to assume FFmpeg is correct and additional 10 bytes should be enough.