### PR TITLE
prevent wrong input of level_idc

### DIFF
--- a/app/xeve_app.c
+++ b/app/xeve_app.c
@@ -907,7 +907,24 @@ static int vui_param_check(XEVE_PARAM * param)
         param->bitstream_restriction_flag = 1;
     }
 
-
+    if (param->level_idc != 40)
+    {
+        int level_idc_check[13] = { 10, 20, 21, 30, 31, 40, 41, 50, 51, 52, 60, 61, 62 };
+        int check = 0;
+        for (int i = 0; i < 13; i++)
+        {
+            if (param->level_idc == level_idc_check[i])
+            {
+                check = 1;
+                break;
+            }
+        }
+        if (check == 0)
+        {
+            ret = 1;
+            logerr("level_idc is wrong value");
+        }
+    }
 
     return ret;
 }

--- a/app/xeve_app_args.h
+++ b/app/xeve_app_args.h
@@ -137,7 +137,9 @@ static const ARGS_OPT args_opt_table[] = \
     },
     {
         ARGS_NO_KEY,  "level-idc", ARGS_VAL_TYPE_INTEGER, 0, NULL,
-        "level setting "
+        "level setting (10, 20, 21, 30, 31, 40, 41, 50, 51, 52, 60, 61, 62)\n"
+        "      input of level is integer with level times 10 (ex> 1 -> 10, 2.1 -> 21)\n"
+        "      Annex A levels[1, 2, 2.1, 3, 3.1, 4, 4.1, 5, 5.1, 5.2, 6, 6.1, 6.2]"
     },
     {
         ARGS_NO_KEY,  "preset", ARGS_VAL_TYPE_STRING, 0, NULL,

--- a/src_base/xeve_enc.c
+++ b/src_base/xeve_enc.c
@@ -2394,6 +2394,7 @@ int xeve_param_init(XEVE_PARAM* param)
 
     param->max_dec_pic_buffering      = 21;
     param->num_reorder_pics           = 21;
+    param->level_idc                  = 40;
     return XEVE_OK;
 }
 


### PR DESCRIPTION
In order to prevent wrong input of level idc #129, input level_idc chechking process is added
And input value of level idc is also described in help message.