### PR TITLE
src_base: cmake: Link libm for the shared library

### DIFF
--- a/src_base/CMakeLists.txt
+++ b/src_base/CMakeLists.txt
@@ -89,6 +89,7 @@ elseif( UNIX OR MINGW )
   endif()
   set_target_properties(${LIB_NAME_BASE}_dynamic PROPERTIES FOLDER lib
                                                             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+  target_link_libraries(${LIB_NAME_BASE}_dynamic m)
   target_compile_definitions( ${LIB_NAME_BASE} PUBLIC ANY LINUX )
   target_link_libraries(${LIB_NAME_BASE} m)
 endif()


### PR DESCRIPTION
Otherwise it fails to link with	errors like so:

```
/usr/bin/ld: /usr/lib/gcc/x86_64-redhat-linux/15/../../../../lib64/libxeveb.so: undefined reference to 'log2'
/usr/bin/ld: /usr/lib/gcc/x86_64-redhat-linux/15/../../../../lib64/libxeveb.so: undefined reference to 'pow'
```